### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#KotMeh
+# KotMeh
 
 This application was written as a test application for using [Kotlin](http://kotlinlang.org) and [Anko](https://github.com/JetBrains/anko) in an MVP architecture alongside varous Java libraries. 
 The application uses [meh.com](http://meh.com)'s api for it's data source.
@@ -6,15 +6,15 @@ The application uses [meh.com](http://meh.com)'s api for it's data source.
 I've tried to utilize various Kotlin features that I found to be pretty useful. 
 You'll see examples of delegated properties, anko UI design, expression body syntax, as well as Java interoperations.
 
-##Building
+## Building
 
 To use this in Android Studio, you're going to need to install the Kotlin [plugin](https://plugins.jetbrains.com/plugin/6954?pr=idea) as well as the Kotlin Extensions [plugin](https://plugins.jetbrains.com/plugin/7717?pr=idea).
 
 You'll also need to copy `meh.properties.example` into `meh.properties` and place your api key in the file.
 
-###Screenshot
+### Screenshot
 ![Shot](https://raw.githubusercontent.com/burntcookie90/KotMeh/master/Screenshot_2015-04-17-00-07-55.png)
 
-###Download
+### Download
 
 You can download the apk [here](https://github.com/burntcookie90/KotMeh/releases/tag/0.1.1)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
